### PR TITLE
Add context menu to decompiler tab folder

### DIFF
--- a/src/main/java/com/samczsun/helios/gui/ClassManager.java
+++ b/src/main/java/com/samczsun/helios/gui/ClassManager.java
@@ -212,6 +212,9 @@ public class ClassManager {
                                     } catch (IOException e1) {
                                         e1.printStackTrace();
                                     }
+                                    editor.getViewport().getView().addMouseListener(new GenericClickListener((clickType, doubleClick) -> {
+                                        ClassManager.this.handleNewTabRequest();
+                                    }, GenericClickListener.ClickType.RIGHT));
 
                                     SwingControl control = new SwingControl(nested, SWT.NONE) {
                                         protected JComponent createSwingComponent() {

--- a/src/main/java/com/samczsun/helios/gui/ClassManager.java
+++ b/src/main/java/com/samczsun/helios/gui/ClassManager.java
@@ -81,6 +81,9 @@ public class ClassManager {
 
                 CTabFolder innerTabFolder = new CTabFolder(mainTabs, SWT.BORDER);
                 fileTab.setControl(innerTabFolder);
+                innerTabFolder.addMouseListener(new GenericClickListener((clickType, doubleClick) -> {
+                    ClassManager.this.handleNewTabRequest();
+                }, GenericClickListener.ClickType.RIGHT));
                 innerTabFolder.addCTabFolder2Listener(new CTabFolder2Adapter() {
                     public void close(CTabFolderEvent event) {
                         ((List<String>) ((Object[]) fileTab.getData())[2]).remove(

--- a/src/main/java/com/samczsun/helios/gui/GenericClickListener.java
+++ b/src/main/java/com/samczsun/helios/gui/GenericClickListener.java
@@ -1,0 +1,88 @@
+package com.samczsun.helios.gui;
+
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.MouseListener;
+
+import java.util.function.BiConsumer;
+
+/**
+ * @author DarkSeraphim.
+ */
+public class GenericClickListener implements MouseListener, java.awt.event.MouseListener {
+
+    enum ClickType {
+        LEFT, MIDDLE, RIGHT;
+        private static ClickType fromButton(int button) {
+            return ClickType.values()[button - 1];
+        }
+    }
+
+    private final BiConsumer<ClickType, Boolean> handler;
+
+    private final byte buttons;
+
+    private final boolean doubleClick;
+
+    public GenericClickListener(BiConsumer<ClickType, Boolean> handler, ClickType type, ClickType...others) {
+        this(handler, false, type, others);
+    }
+
+    public GenericClickListener(BiConsumer<ClickType, Boolean> handler, boolean doubleClick, ClickType type, ClickType...others) {
+        this.handler = handler;
+        this.doubleClick = doubleClick;
+        int buttons = 1 << type.ordinal();
+        for (ClickType otherType : others) {
+            buttons |= 1 << otherType.ordinal();
+        }
+        this.buttons = (byte) buttons;
+    }
+
+    /* *
+     * SWT events
+     * */
+
+    @Override
+    public void mouseDoubleClick(MouseEvent event) {
+        handle(ClickType.fromButton(event.button), true);
+    }
+
+    @Override
+    public void mouseDown(MouseEvent event) {
+    }
+
+    private void handle(ClickType type, boolean doubleClick) {
+        if (this.doubleClick == doubleClick && (this.buttons & (1 << (type.ordinal()))) != 0) {
+            this.handler.accept(type, doubleClick);
+        }
+    }
+
+    @Override
+    public void mouseUp(MouseEvent event) {
+        handle(ClickType.fromButton(event.button), false);
+    }
+
+    /* *
+     * AWT events
+     * */
+
+    @Override
+    public void mouseClicked(java.awt.event.MouseEvent e) {
+        handle(ClickType.fromButton(e.getButton()), false);
+    }
+
+    @Override
+    public void mousePressed(java.awt.event.MouseEvent e) {
+    }
+
+    @Override
+    public void mouseReleased(java.awt.event.MouseEvent e) {
+    }
+
+    @Override
+    public void mouseEntered(java.awt.event.MouseEvent e) {
+    }
+
+    @Override
+    public void mouseExited(java.awt.event.MouseEvent e) {
+    }
+}

--- a/src/main/java/com/samczsun/helios/gui/GenericClickListener.java
+++ b/src/main/java/com/samczsun/helios/gui/GenericClickListener.java
@@ -10,7 +10,7 @@ import java.util.function.BiConsumer;
  */
 public class GenericClickListener implements MouseListener, java.awt.event.MouseListener {
 
-    enum ClickType {
+    public enum ClickType {
         LEFT, MIDDLE, RIGHT;
         private static ClickType fromButton(int button) {
             return ClickType.values()[button - 1];

--- a/src/main/java/com/samczsun/helios/handler/files/CatchAllHandler.java
+++ b/src/main/java/com/samczsun/helios/handler/files/CatchAllHandler.java
@@ -18,6 +18,7 @@ package com.samczsun.helios.handler.files;
 
 import com.samczsun.helios.Helios;
 import com.samczsun.helios.LoadedFile;
+import com.samczsun.helios.gui.GenericClickListener;
 import com.samczsun.helios.handler.ExceptionHandler;
 import org.eclipse.albireo.core.SwingControl;
 import org.eclipse.swt.SWT;
@@ -40,6 +41,9 @@ public class CatchAllHandler extends FileHandler {
         } catch (IOException e1) {
             ExceptionHandler.handle(e1);
         }
+        editor.getViewport().getView().addMouseListener(new GenericClickListener((clickType, doubleClick) -> {
+            Helios.getGui().getClassManager().handleNewTabRequest();
+        }, GenericClickListener.ClickType.RIGHT));
 
         SwingControl control = new SwingControl(parent, SWT.NONE) {
             protected JComponent createSwingComponent() {


### PR DESCRIPTION
Allows users to use a different compiler when right clicking the decompiler tab folder. Like CTRL + T, but it doesn't work with text areas as they already have their own context area (and I want to avoid editorial conflicts :wink:)